### PR TITLE
用国内镜像源取代jcenter()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion 30
         versionCode 16
         versionName "1.0-beta16"
-        ndk { abiFilters "armeabi", "x86"}
+        ndk { abiFilters "armeabi", "x86" }
         resConfigs "zh"
     }
     compileOptions {
@@ -30,6 +30,8 @@ android {
 
 allprojects {
     repositories {
+        mavenCentral()
+        maven { url 'https://maven.aliyun.com/repository/jcenter' }
         maven { url "https://jitpack.io" }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        maven { url 'https://maven.aliyun.com/repository/jcenter' }
         mavenCentral()
         maven {
             url 'http://4thline.org/m2'
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.jakewharton:butterknife-gradle-plugin:10.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -20,7 +20,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        maven { url 'https://maven.aliyun.com/repository/jcenter' }
         mavenCentral()
         maven {
             url 'http://4thline.org/m2'


### PR DESCRIPTION
jcenter已经停止运营，虽然他声明只读模式，但是经下载发现build只会抛出warning，不报错，而项目里没有成功依赖相关的包。因此，若要继续使用，应该更改为国内镜像源。